### PR TITLE
Update Remove-JNDILookup.ps1

### DIFF
--- a/Remove-JNDILookup.ps1
+++ b/Remove-JNDILookup.ps1
@@ -6,7 +6,7 @@
 
     .PARAMETER FullName
         name of the file.  Can be passed as a string parameter, as a list of filenames, or in a FileSystemObject. See Examples.
-    
+
     .PARAMETER LogFile
         name of logfile for all actions, defaults to Remove-JNDILookup.txt
 
@@ -28,142 +28,138 @@
         Get-ChildItem *.jar | .\Remove-JNDILookup.ps1
 
     .NOTES
-        This won't dine into a ZIP file or a WAR file to find the enclosed JAR files
+        This won't dive into a ZIP file or a WAR file to find the enclosed JAR files
 
     .LINK
         https://github.com/jbalcorn/Remove-JNDILookup
-        
+
 #>
 [cmdletBinding()]
 Param(
     [Parameter(
-        Mandatory = $true, 
-        ValueFromPipelineByPropertyName = $true,
-        ValueFromPipeline = $true
+        Mandatory,
+        ValueFromPipelineByPropertyName,
+        ValueFromPipeline
     )]$FullName,
     $Logfile = "Remove-JNDILookup.txt"
 )
+
 Begin {
     Add-Type -AssemblyName System.IO.Compression
     Add-Type -AssemblyName System.IO.Compression.Filesystem
-
 
     Function New-LogObj {
         <#
             .SYNOPSIS
             Creates an object that can be consumed by Write-LogLine
-    
+
             .DESCRIPTION
             Creates an object that points to a logfile and contains a default message
-    
+
             .PARAMETER logfile
-            Specifies the name of the log file. 
-    
+            Specifies the name of the log file.
+
             .PARAMETER function
             If this parameter exists, the default message will contain it and the date.
-    
+
             .INPUTS
             The name of the logfile and, if passed by name, the function parameter
-    
+
             .OUTPUTS
             The object that can be consumed by Write-LogLine
-    
+
             .EXAMPLE
             PS> $msg = Get-LogObj $logfile # Return obj has date in default message
-    
+
             .EXAMPLE
             PS> $msg = Get-LogObj -logfile "SomeLogFile.txt" # Return obj has date in default message
-    
+
             .EXAMPLE
-            PS> $msg = $logfile | Get-LogObj 
-            
+            PS> $msg = $logfile | Get-LogObj
+
             .EXAMPLE
             PS> $msg = $logfile | Get-LogObj -function "MyFunction"  # return object has "MyFunction: (Get-Date)" in edfault message
-            
-        
-    
         #>
+
         Param(
             [Parameter(
-                Mandatory = $true,
-                ValueFromPipelineByPropertyName = $true)]
+                Mandatory,
+                ValueFromPipelineByPropertyName)]
             [string]$logfile,
-            [Parameter(Mandatory = $false,
-                ValueFromPipelineByPropertyName = $true)]
+            [Parameter(ValueFromPipelineByPropertyName)]
             [string]$function
         )
+
         if ($function) {
             $msg = "$($function): $(Get-Date)"
         }
         else {
             $msg = Get-Date
         }
-        return New-Object -TypeName PSObject -Property @{
+
+        [PSCustomObject]@{
             logfile = $logfile
             message = $msg
         }
     }
-    
+
     Function Write-LogLine {
         <#
             .SYNOPSIS
             Logs the input message, and optionally outputs to the console
-    
+
             .DESCRIPTION
             Allows every message to be logged and optionally output to the console in a single line.
-    
+
             .PARAMETER message
             The string to be output
-    
+
             .PARAMETER logfile
             The name of the logfile
-    
+
             .PARAMETER console
             switch.  if true, output the message to the console
-    
+
             .INPUTS
             [string]$message
             [string]$logfile
             [switch]$console
-    
+
             .OUTPUTS
             No Output on pipeline
-    
+
             .EXAMPLE
             Write-LogLine -logfile "my.txt" -message "A log file line" -console    # Outputs the message to the file and to the console
-    
+
             .EXAMPLE
             $msg = Get-LogObj "My.txt"
             $msg | Write-LogLine    # Outputs the current date and time to the logfile
-            $msg | Write-LogLine -message "A informational message"   
+            $msg | Write-LogLine -message "A informational message"
             $msg | Write-LogLine -console -message "A more urgent message"   # Write to logfile and console
-    
- 
         #>
-    
+
         Param(
             [Parameter(
-                Mandatory = $true,
-                ValueFromPipelineByPropertyName = $true)]
+                Mandatory,
+                ValueFromPipelineByPropertyName)]
             [string]$message,
             [Parameter(
-                Mandatory = $true,
-                ValueFromPipelineByPropertyName = $true)]
+                Mandatory,
+                ValueFromPipelineByPropertyName)]
             [string]$logfile,
-            [Parameter(
-                Mandatory = $false)]
+            [Parameter()]
             [switch]$console
         )
         # Add an extra space so if file is set as outlook message, outlook will not remove line breaks.
         "$($message) " | Out-File -Append $logfile
-        if ($console) {
+        if ($console.IsPresent) {
             Write-Host $message
-        }   
+        }
     }
 
     $log = New-LogObj -logfile $logfile -Function $MyInvocation.MyCommand.Name
     $log | Write-LogLine
-    $Output = @()
+    $Output = [System.Collections.Generic.List[System.Object]]::new()
 }
 
 Process {
@@ -173,23 +169,23 @@ Process {
     }
     catch {
         Write-Host "Cannot find $($Fullname)"
-        $Output += New-Object -TypeName PSObject -Property @{
-            FullName = $FullName
-            Result = "Could not resolve path: $($Error[0])"
-        }
-        return
+        $Output.Add([PSCustomObject]@{
+            FullName = $fn.Path
+            Result   = "Could not resolve path: $($Error[0])"
+        })
     }
+
     try {
         $zip = [System.io.Compression.ZipFile]::Open("$fn", "Read")
     }
     catch {
         Write-Host "Cannot open $($Fullname) as a Zip File. $($Error[0])"
-        $Output += New-Object -TypeName PSObject -Property @{
+        $Output.Add([PSCustomObject]@{
             FullName = $fn.Path
-            Result = "Could not open as a ZIP file: $($Error[0])"
-        }
-        Return
+            Result   = "Could not open as a ZIP file: $($Error[0])"
+        })
     }
+
     $file = $zip.Entries | Where-Object { $_.name -eq "JNDILookup.class" }
 
     if ($null -ne $file) {
@@ -198,6 +194,7 @@ Process {
         $choices = '&Yes', '&No'
 
         $decision = $Host.UI.PromptForChoice($title, $question, $choices, 1)
+
         if ($decision -eq 0) {
             Write-Host "Backing up $($fn) to $($fn).bak"
             # Close Zip so it can be copied
@@ -207,30 +204,31 @@ Process {
             $zip = [System.io.Compression.ZipFile]::Open($fn, "Update")
             $files = $zip.Entries.Where( { $_.name -eq "JNDILookup.class" } )
             $log | Write-LogLine -message "$($fn): Backing up as $($fn).bak"
+
             foreach ($file in $files) {
                 $log | Write-LogLine  -console -message "$($fn):     Removing $($File.Fullname)"
                 $file.Delete()
-                $Output += New-Object -TypeName PSObject -Property @{
+                $Output.add([PSCustomObject]@{
                     FullName = $fn.Path
-                    Result = "$($File.Fullname) Removed"
-                }
+                    Result   = "$($File.Fullname) Removed"
+                })
             }
         }
         else {
             Write-Host 'cancelled'
-            $Output += New-Object -TypeName PSObject -Property @{
+            $Output.Add([PSCustomObject]@{
                 FullName = $fn.Path
-                Result = "Did not process - `No` Chosen"
-            }
+                Result   = "Did not process - `No` Chosen"
+            })
         }
 
     }
     else {
         $log | Write-LogLine -message "$($fn): JNDILookup.class Not Found"
-        $Output += New-Object -TypeName PSObject -Property @{
+        $Output.Add([PSCustomObject]@{
             FullName = $fn.Path
-            Result = "JNDILookup.class not found in file"
-        }
+            Result   = "JNDILookup.class not found in file"
+        })
     }
     $zip.Dispose()
 }


### PR DESCRIPTION
Cleaned up code, changed output to add to array so it doesn't have to destroy and recreate each time an entry is made.  Removed superfluous returns.

The param's don't need to have the $true as just having the name in it acts as it being true.  Updated $console switch to best practice for switches.

Corrected misspelling in script help.

Multiple other changes mainly to how a pscustomobject is created.